### PR TITLE
feat(ragas): add target comparison and RAGPROBE_TARGET_URL support (fixes #10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,43 @@ jobs:
           sys.exit(1 if errors else 0)
           "
 
+  validate-ragas-scripts:
+    name: Validate Ragas scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Syntax check Ragas scripts
+        run: |
+          python -m py_compile scripts/run_ragas_eval.py
+          python -m py_compile scripts/compare_targets.py
+          python -m py_compile scripts/run_baseline.py
+          python -m py_compile ragas_eval.py
+          python -m py_compile ragas_metrics.py
+      - name: Verify compare_targets CLI loads
+        run: |
+          python -c "
+          import sys
+          sys.path.insert(0, 'scripts')
+          from compare_targets import query_target, print_comparison, TargetScores, METRICS
+          print(f'Metrics: {METRICS}')
+          print('compare_targets module loads correctly')
+          "
+
+  test-compare-targets:
+    name: Test compare_targets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - run: pip install --quiet pytest pyyaml
+      - name: Run compare_targets unit tests
+        run: pytest tests/test_compare_targets.py -v
+
   lint-shell:
     name: ShellCheck
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ history.json
 !package.json
 !promptfooconfig.js
 __pycache__/
+ragprobe.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,14 +112,37 @@ CREATE TABLE probe_results (
 
 ### Running Ragas evaluation
 ```bash
-python scripts/run_ragas_eval.py
+# Against ragpipe (non-agentic)
+RAGPROBE_TARGET_URL=http://localhost:8090 python scripts/run_ragas_eval.py --store --target ragpipe-v1
+
+# Against ragorchestrator (agentic with CRAG)
+RAGPROBE_TARGET_URL=http://localhost:8095 python scripts/run_ragas_eval.py --store --target ragorchestrator-crag
+
+# Against ragorchestrator (agentic full loop)
+RAGPROBE_TARGET_URL=http://localhost:8095 python scripts/run_ragas_eval.py --store --target ragorchestrator-full
 ```
+
+### Comparing targets
+```bash
+# Compare agentic vs non-agentic
+python scripts/compare_targets.py --baseline ragpipe-v1 --target ragorchestrator-crag
+
+# With regression threshold (ignore deltas < 0.05)
+python scripts/compare_targets.py --baseline baseline --target crag-v1 --threshold 0.05
+
+# JSON output for automation
+python scripts/compare_targets.py --baseline ragpipe-v1 --target ragorchestrator-crag --json
+```
+
+Exit code 1 if regressions detected. Per-route breakdown flags which specific
+routes regressed. Use this to prove agentic loop improves quality.
 
 ### Key files
 ```
-ragas_eval.py           — Ragas evaluation logic
-ragas_metrics.py        — Ragas metric wrappers
-scripts/run_ragas_eval.py — CLI script to run full pipeline
-ragas/corpus.yaml      — Test corpus for Ragas evaluation
-tests/ragas_eval.yaml  — Ragas test configuration
+ragas_eval.py               — Ragas evaluation logic
+ragas_metrics.py            — Ragas metric wrappers
+scripts/run_ragas_eval.py   — CLI script to run full pipeline
+scripts/compare_targets.py  — Compare scores between two targets
+ragas/corpus.yaml           — Test corpus for Ragas evaluation
+tests/test_compare_targets.py — Unit tests for comparison logic
 ```

--- a/scripts/compare_targets.py
+++ b/scripts/compare_targets.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Compare Ragas evaluation scores between two targets.
+
+Queries probe_results for two target labels, computes per-metric and per-route
+score deltas, prints a comparison table, and flags regressions where the
+candidate target scores lower than the baseline.
+
+Usage:
+    python scripts/compare_targets.py --baseline ragpipe-v1 --target ragorchestrator-crag
+    python scripts/compare_targets.py --baseline baseline --target crag-v1
+    python scripts/compare_targets.py --baseline baseline --target crag-v1 --threshold 0.05
+
+Environment:
+    DOCSTORE_URL   Postgres URL (optional, falls back to SQLite)
+
+Exit codes:
+    0  No regressions detected
+    1  At least one metric regressed beyond threshold
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+SQLITE_DB = SCRIPT_DIR / "ragprobe.db"
+
+METRICS = ["faithfulness", "answer_relevance", "context_precision", "context_recall"]
+
+
+@dataclass
+class TargetScores:
+    """Aggregate scores for a target, optionally broken down by route."""
+
+    target: str
+    n: int
+    metrics: dict[str, float | None]
+    by_route: dict[str, dict[str, float | None]]
+    last_run: str | None
+
+
+def _avg(values: list[float | None]) -> float | None:
+    clean = [v for v in values if v is not None]
+    return sum(clean) / len(clean) if clean else None
+
+
+def _query_sqlite(target_label: str) -> TargetScores:
+    """Query SQLite for latest eval run scores."""
+    conn = sqlite3.connect(SQLITE_DB)
+    conn.row_factory = sqlite3.Row
+
+    # Get the latest eval_run_id for this target
+    row = conn.execute(
+        """SELECT eval_run_id, MAX(eval_run_at) as last_run
+           FROM probe_results WHERE target = ?
+           GROUP BY eval_run_id ORDER BY last_run DESC LIMIT 1""",
+        (target_label,),
+    ).fetchone()
+
+    if not row:
+        conn.close()
+        return TargetScores(
+            target=target_label, n=0, metrics={}, by_route={}, last_run=None
+        )
+
+    run_id = row["eval_run_id"]
+    last_run = row["last_run"]
+
+    rows = conn.execute(
+        """SELECT question, faithfulness, answer_relevance,
+                  context_precision, context_recall, routing
+           FROM probe_results WHERE eval_run_id = ?""",
+        (run_id,),
+    ).fetchall()
+    conn.close()
+
+    return _build_scores(target_label, rows, last_run)
+
+
+def _query_postgres(target_label: str) -> TargetScores:
+    """Query Postgres for latest eval run scores."""
+    import psycopg2
+    import psycopg2.extras
+
+    conn = psycopg2.connect(os.environ["DOCSTORE_URL"])
+    cursor = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+
+    cursor.execute(
+        """SELECT eval_run_id, MAX(eval_run_at) as last_run
+           FROM probe_results WHERE target = %s
+           GROUP BY eval_run_id ORDER BY last_run DESC LIMIT 1""",
+        (target_label,),
+    )
+    row = cursor.fetchone()
+
+    if not row:
+        conn.close()
+        return TargetScores(
+            target=target_label, n=0, metrics={}, by_route={}, last_run=None
+        )
+
+    run_id = row["eval_run_id"]
+    last_run = str(row["last_run"])
+
+    cursor.execute(
+        """SELECT question, faithfulness, answer_relevance,
+                  context_precision, context_recall, routing
+           FROM probe_results WHERE eval_run_id = %s""",
+        (run_id,),
+    )
+    rows = cursor.fetchall()
+    conn.close()
+
+    return _build_scores(target_label, rows, last_run)
+
+
+def _build_scores(target_label: str, rows: list, last_run: str | None) -> TargetScores:
+    """Build TargetScores from query rows."""
+    by_route: dict[str, list[dict]] = {}
+    all_scores: dict[str, list[float | None]] = {m: [] for m in METRICS}
+
+    for r in rows:
+        route = r["routing"] or "unknown"
+        by_route.setdefault(route, []).append(r)
+        for m in METRICS:
+            val = r[m]
+            all_scores[m].append(float(val) if val is not None else None)
+
+    aggregate = {m: _avg(all_scores[m]) for m in METRICS}
+
+    route_scores = {}
+    for route, route_rows in by_route.items():
+        route_metrics: dict[str, list[float | None]] = {m: [] for m in METRICS}
+        for r in route_rows:
+            for m in METRICS:
+                val = r[m]
+                route_metrics[m].append(float(val) if val is not None else None)
+        route_scores[route] = {m: _avg(route_metrics[m]) for m in METRICS}
+
+    return TargetScores(
+        target=target_label,
+        n=len(rows),
+        metrics=aggregate,
+        by_route=route_scores,
+        last_run=last_run,
+    )
+
+
+def query_target(target_label: str) -> TargetScores:
+    """Query scores for a target from the appropriate storage backend."""
+    if os.environ.get("DOCSTORE_URL"):
+        return _query_postgres(target_label)
+    if SQLITE_DB.exists():
+        return _query_sqlite(target_label)
+    print(f"Error: No storage backend available (no DOCSTORE_URL and no {SQLITE_DB})")
+    sys.exit(1)
+
+
+def _fmt(v: float | None) -> str:
+    return f"{v:.3f}" if v is not None else "N/A"
+
+
+def _delta_str(baseline: float | None, candidate: float | None) -> str:
+    if baseline is None or candidate is None:
+        return "N/A"
+    d = candidate - baseline
+    sign = "+" if d >= 0 else ""
+    return f"{sign}{d:.3f}"
+
+
+def _is_regression(
+    baseline: float | None, candidate: float | None, threshold: float
+) -> bool:
+    if baseline is None or candidate is None:
+        return False
+    return (baseline - candidate) > threshold
+
+
+def print_comparison(
+    baseline: TargetScores, candidate: TargetScores, threshold: float
+) -> list[str]:
+    """Print comparison table and return list of regression descriptions."""
+    regressions: list[str] = []
+
+    print(f"\n{'=' * 72}")
+    print(f"Comparison: {baseline.target} vs {candidate.target}")
+    print(f"{'=' * 72}")
+    print(f"  Baseline:  {baseline.target} ({baseline.n} pairs, {baseline.last_run})")
+    print(f"  Candidate: {candidate.target} ({candidate.n} pairs, {candidate.last_run})")
+    print(f"  Regression threshold: {threshold}")
+    print()
+
+    # Aggregate comparison
+    print("Aggregate Scores:")
+    print(f"  {'Metric':<20} {'Baseline':>10} {'Candidate':>10} {'Delta':>10} {'Status':>10}")
+    print(f"  {'-' * 20} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 10}")
+
+    for m in METRICS:
+        b = baseline.metrics.get(m)
+        c = candidate.metrics.get(m)
+        delta = _delta_str(b, c)
+        regressed = _is_regression(b, c, threshold)
+        status = "REGRESSED" if regressed else ("improved" if c and b and c > b else "")
+        print(f"  {m:<20} {_fmt(b):>10} {_fmt(c):>10} {delta:>10} {status:>10}")
+        if regressed:
+            regressions.append(f"Aggregate {m}: {_fmt(b)} -> {_fmt(c)} ({delta})")
+
+    # Per-route comparison
+    all_routes = sorted(set(list(baseline.by_route.keys()) + list(candidate.by_route.keys())))
+    if all_routes:
+        print(f"\nPer-Route Breakdown:")
+        for route in all_routes:
+            b_route = baseline.by_route.get(route, {})
+            c_route = candidate.by_route.get(route, {})
+            print(f"\n  Route: {route}")
+            print(f"    {'Metric':<20} {'Baseline':>10} {'Candidate':>10} {'Delta':>10} {'Status':>10}")
+            print(f"    {'-' * 20} {'-' * 10} {'-' * 10} {'-' * 10} {'-' * 10}")
+
+            for m in METRICS:
+                b = b_route.get(m)
+                c = c_route.get(m)
+                delta = _delta_str(b, c)
+                regressed = _is_regression(b, c, threshold)
+                status = "REGRESSED" if regressed else (
+                    "improved" if c and b and c > b else ""
+                )
+                print(f"    {m:<20} {_fmt(b):>10} {_fmt(c):>10} {delta:>10} {status:>10}")
+                if regressed:
+                    regressions.append(
+                        f"Route {route} {m}: {_fmt(b)} -> {_fmt(c)} ({delta})"
+                    )
+
+    print()
+
+    if regressions:
+        print(f"REGRESSIONS DETECTED ({len(regressions)}):")
+        for r in regressions:
+            print(f"  - {r}")
+    else:
+        print("No regressions detected.")
+
+    print()
+    return regressions
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare Ragas scores between two evaluation targets"
+    )
+    parser.add_argument(
+        "--baseline",
+        required=True,
+        help="Baseline target label (e.g. ragpipe-v1, baseline)",
+    )
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="Candidate target label (e.g. ragorchestrator-crag, crag-v1)",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.0,
+        help="Regression threshold — flag if candidate is worse by more than this (default: 0.0)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="output_json",
+        help="Output comparison as JSON",
+    )
+    args = parser.parse_args()
+
+    baseline = query_target(args.baseline)
+    candidate = query_target(args.target)
+
+    if baseline.n == 0:
+        print(f"Error: No results found for baseline target '{args.baseline}'")
+        sys.exit(1)
+
+    if candidate.n == 0:
+        print(f"Error: No results found for candidate target '{args.target}'")
+        sys.exit(1)
+
+    if args.output_json:
+        result = {
+            "baseline": {
+                "target": baseline.target,
+                "n": baseline.n,
+                "last_run": baseline.last_run,
+                "metrics": baseline.metrics,
+                "by_route": baseline.by_route,
+            },
+            "candidate": {
+                "target": candidate.target,
+                "n": candidate.n,
+                "last_run": candidate.last_run,
+                "metrics": candidate.metrics,
+                "by_route": candidate.by_route,
+            },
+            "regressions": [],
+        }
+        for m in METRICS:
+            if _is_regression(
+                baseline.metrics.get(m), candidate.metrics.get(m), args.threshold
+            ):
+                result["regressions"].append(
+                    {
+                        "scope": "aggregate",
+                        "metric": m,
+                        "baseline": baseline.metrics.get(m),
+                        "candidate": candidate.metrics.get(m),
+                    }
+                )
+        print(json.dumps(result, indent=2, default=str))
+        sys.exit(1 if result["regressions"] else 0)
+
+    regressions = print_comparison(baseline, candidate, args.threshold)
+    sys.exit(1 if regressions else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ragas_eval.py
+++ b/scripts/run_ragas_eval.py
@@ -10,6 +10,7 @@ Usage:
     python scripts/run_ragas_eval.py --judge http://lennon:8080
 
 Environment:
+    RAGPROBE_TARGET_URL     Default target URL when --target-url not given
     RAGPROBE_TARGETS_FILE   Path to targets.yaml (default: targets.yaml)
     RAGAS_JUDGE_URL        Judge LLM URL (default: http://localhost:8080)
     RAGAS_JUDGE_MODEL      Judge model name (default: qwen3.5)
@@ -271,10 +272,12 @@ def main():
         "model": args.judge_model or os.environ.get("RAGAS_JUDGE_MODEL", "qwen3.5"),
     }
 
-    if args.target_url:
+    target_url = args.target_url or os.environ.get("RAGPROBE_TARGET_URL")
+
+    if target_url:
         token = args.token or os.environ.get("RAGPIPE_ADMIN_TOKEN", "")
         run_single_target(
-            target_url=args.target_url,
+            target_url=target_url,
             token=token,
             corpus=corpus,
             judge_config=judge_config,

--- a/targets.yaml.example
+++ b/targets.yaml.example
@@ -1,8 +1,21 @@
 # ragprobe targets — copy to targets.yaml and fill in real values
 # Add as many targets as needed — the comparison matrix grows automatically
 targets:
-  - label: local
+  # Non-agentic baseline (ragpipe direct)
+  - label: ragpipe-v1
     url: http://localhost:8090
+    token: your-admin-token
+    model: qwen3.5
+
+  # Agentic with CRAG only (ragorchestrator)
+  - label: ragorchestrator-crag
+    url: http://localhost:8095
+    token: your-admin-token
+    model: qwen3.5
+
+  # Agentic with full loop (ragorchestrator)
+  - label: ragorchestrator-full
+    url: http://localhost:8095
     token: your-admin-token
     model: qwen3.5
 

--- a/tests/test_compare_targets.py
+++ b/tests/test_compare_targets.py
@@ -1,0 +1,238 @@
+"""Tests for scripts/compare_targets.py comparison logic."""
+
+import sqlite3
+import sys
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPT_DIR / "scripts"))
+import compare_targets
+
+
+@pytest.fixture
+def sqlite_db(tmp_path):
+    """Create a temporary SQLite database with probe_results."""
+    db_path = tmp_path / "ragprobe.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("""
+        CREATE TABLE probe_results (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            eval_run_id TEXT NOT NULL,
+            eval_run_at TEXT NOT NULL,
+            target TEXT NOT NULL,
+            ragpipe_version TEXT,
+            model TEXT,
+            question TEXT NOT NULL,
+            ground_truth TEXT,
+            answer TEXT NOT NULL,
+            context_chunks TEXT NOT NULL,
+            faithfulness REAL,
+            answer_relevance REAL,
+            context_precision REAL,
+            context_recall REAL,
+            routing TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _insert_results(db_path, target, scores_by_route):
+    """Insert test results into the database.
+
+    scores_by_route: dict of route -> list of (f, ar, cp, cr) tuples
+    """
+    conn = sqlite3.connect(db_path)
+    run_id = str(uuid.uuid4())
+    run_at = datetime.now(UTC).isoformat()
+
+    for route, scores_list in scores_by_route.items():
+        for i, (f, ar, cp, cr) in enumerate(scores_list):
+            conn.execute(
+                """INSERT INTO probe_results (
+                    eval_run_id, eval_run_at, target, question, answer,
+                    context_chunks, faithfulness, answer_relevance,
+                    context_precision, context_recall, routing
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    run_id, run_at, target,
+                    f"test question {route} {i}", "test answer",
+                    "[]", f, ar, cp, cr, route,
+                ),
+            )
+    conn.commit()
+    conn.close()
+
+
+class TestBuildScores:
+    def test_avg_helper(self):
+        assert compare_targets._avg([0.5, 0.7, 0.9]) == pytest.approx(0.7)
+        assert compare_targets._avg([None, 0.8, None]) == pytest.approx(0.8)
+        assert compare_targets._avg([None, None]) is None
+        assert compare_targets._avg([]) is None
+
+    def test_delta_str_positive(self):
+        assert compare_targets._delta_str(0.5, 0.8) == "+0.300"
+
+    def test_delta_str_negative(self):
+        assert compare_targets._delta_str(0.8, 0.5) == "-0.300"
+
+    def test_delta_str_none(self):
+        assert compare_targets._delta_str(None, 0.5) == "N/A"
+        assert compare_targets._delta_str(0.5, None) == "N/A"
+
+    def test_is_regression_true(self):
+        assert compare_targets._is_regression(0.8, 0.5, 0.0) is True
+
+    def test_is_regression_false_when_improved(self):
+        assert compare_targets._is_regression(0.5, 0.8, 0.0) is False
+
+    def test_is_regression_within_threshold(self):
+        assert compare_targets._is_regression(0.8, 0.75, 0.1) is False
+
+    def test_is_regression_none_values(self):
+        assert compare_targets._is_regression(None, 0.5, 0.0) is False
+        assert compare_targets._is_regression(0.5, None, 0.0) is False
+
+
+class TestQuerySQLite:
+    def test_query_empty_target(self, sqlite_db):
+        with patch.object(compare_targets, "SQLITE_DB", sqlite_db):
+            scores = compare_targets._query_sqlite("nonexistent")
+            assert scores.n == 0
+            assert scores.metrics == {}
+            assert scores.last_run is None
+
+    def test_query_single_route(self, sqlite_db):
+        _insert_results(sqlite_db, "baseline", {
+            "personnel": [(0.9, 0.8, 0.7, 0.6)],
+        })
+        with patch.object(compare_targets, "SQLITE_DB", sqlite_db):
+            scores = compare_targets._query_sqlite("baseline")
+            assert scores.n == 1
+            assert scores.metrics["faithfulness"] == pytest.approx(0.9)
+            assert scores.metrics["answer_relevance"] == pytest.approx(0.8)
+            assert "personnel" in scores.by_route
+
+    def test_query_multiple_routes(self, sqlite_db):
+        _insert_results(sqlite_db, "baseline", {
+            "personnel": [(0.9, 0.8, 0.7, 0.6), (0.7, 0.6, 0.5, 0.4)],
+            "lookup": [(0.3, 0.4, 0.5, 0.2)],
+        })
+        with patch.object(compare_targets, "SQLITE_DB", sqlite_db):
+            scores = compare_targets._query_sqlite("baseline")
+            assert scores.n == 3
+            assert scores.metrics["faithfulness"] == pytest.approx((0.9 + 0.7 + 0.3) / 3)
+            assert "personnel" in scores.by_route
+            assert "lookup" in scores.by_route
+            assert scores.by_route["personnel"]["faithfulness"] == pytest.approx(0.8)
+            assert scores.by_route["lookup"]["faithfulness"] == pytest.approx(0.3)
+
+
+class TestPrintComparison:
+    def test_no_regressions(self, capsys):
+        baseline = compare_targets.TargetScores(
+            target="baseline", n=5, last_run="2026-01-01",
+            metrics={"faithfulness": 0.7, "answer_relevance": 0.8,
+                     "context_precision": 0.7, "context_recall": 0.25},
+            by_route={},
+        )
+        candidate = compare_targets.TargetScores(
+            target="crag-v1", n=5, last_run="2026-01-02",
+            metrics={"faithfulness": 0.8, "answer_relevance": 0.85,
+                     "context_precision": 0.75, "context_recall": 0.3},
+            by_route={},
+        )
+        regressions = compare_targets.print_comparison(baseline, candidate, 0.0)
+        assert len(regressions) == 0
+        output = capsys.readouterr().out
+        assert "No regressions detected" in output
+
+    def test_regression_detected(self, capsys):
+        baseline = compare_targets.TargetScores(
+            target="baseline", n=5, last_run="2026-01-01",
+            metrics={"faithfulness": 0.9, "answer_relevance": 0.8,
+                     "context_precision": 0.7, "context_recall": 0.5},
+            by_route={},
+        )
+        candidate = compare_targets.TargetScores(
+            target="crag-v1", n=5, last_run="2026-01-02",
+            metrics={"faithfulness": 0.5, "answer_relevance": 0.85,
+                     "context_precision": 0.75, "context_recall": 0.3},
+            by_route={},
+        )
+        regressions = compare_targets.print_comparison(baseline, candidate, 0.0)
+        assert len(regressions) == 2  # faithfulness and context_recall
+        output = capsys.readouterr().out
+        assert "REGRESSIONS DETECTED" in output
+        assert "faithfulness" in output.lower()
+
+    def test_threshold_suppresses_small_regressions(self, capsys):
+        baseline = compare_targets.TargetScores(
+            target="baseline", n=5, last_run="2026-01-01",
+            metrics={"faithfulness": 0.75, "answer_relevance": 0.8,
+                     "context_precision": 0.7, "context_recall": 0.25},
+            by_route={},
+        )
+        candidate = compare_targets.TargetScores(
+            target="crag-v1", n=5, last_run="2026-01-02",
+            metrics={"faithfulness": 0.72, "answer_relevance": 0.85,
+                     "context_precision": 0.75, "context_recall": 0.25},
+            by_route={},
+        )
+        regressions = compare_targets.print_comparison(baseline, candidate, 0.05)
+        assert len(regressions) == 0
+
+    def test_per_route_regressions(self, capsys):
+        baseline = compare_targets.TargetScores(
+            target="baseline", n=5, last_run="2026-01-01",
+            metrics={"faithfulness": 0.7, "answer_relevance": 0.8,
+                     "context_precision": 0.7, "context_recall": 0.25},
+            by_route={"lookup": {"faithfulness": 0.9, "answer_relevance": 0.8,
+                                  "context_precision": 0.7, "context_recall": 0.25}},
+        )
+        candidate = compare_targets.TargetScores(
+            target="crag-v1", n=5, last_run="2026-01-02",
+            metrics={"faithfulness": 0.8, "answer_relevance": 0.85,
+                     "context_precision": 0.75, "context_recall": 0.3},
+            by_route={"lookup": {"faithfulness": 0.4, "answer_relevance": 0.8,
+                                  "context_precision": 0.7, "context_recall": 0.25}},
+        )
+        regressions = compare_targets.print_comparison(baseline, candidate, 0.0)
+        assert any("Route lookup" in r and "faithfulness" in r for r in regressions)
+
+
+class TestEndToEnd:
+    def test_full_comparison_pipeline(self, sqlite_db):
+        """End-to-end: insert baseline + candidate, query both, compare."""
+        _insert_results(sqlite_db, "ragpipe-v1", {
+            "personnel": [(0.967, 0.9, 0.85, 0.7)],
+            "lookup": [(0.333, 0.6, 0.5, 0.2)],
+            "general": [(0.7, 0.8, None, None)],
+        })
+        _insert_results(sqlite_db, "ragorchestrator-crag", {
+            "personnel": [(0.95, 0.9, 0.85, 0.7)],
+            "lookup": [(0.65, 0.7, 0.6, 0.35)],
+            "general": [(0.7, 0.8, None, None)],
+        })
+
+        with patch.object(compare_targets, "SQLITE_DB", sqlite_db):
+            baseline = compare_targets.query_target("ragpipe-v1")
+            candidate = compare_targets.query_target("ragorchestrator-crag")
+
+        assert baseline.n == 3
+        assert candidate.n == 3
+
+        # MPEP/lookup should show improvement
+        assert candidate.by_route["lookup"]["faithfulness"] > baseline.by_route["lookup"]["faithfulness"]
+
+        # Personnel slight regression is expected
+        regressions = compare_targets.print_comparison(baseline, candidate, 0.05)
+        # Personnel faithfulness dropped 0.967->0.95 which is within 0.05 threshold
+        assert not any("personnel" in r.lower() and "faithfulness" in r for r in regressions)


### PR DESCRIPTION
Closes #10

## Problem
ragprobe could only evaluate against ragpipe. No way to compare scores between ragpipe (non-agentic) and ragorchestrator (agentic), or detect quality regressions.

## Solution
- Added `RAGPROBE_TARGET_URL` env var to `run_ragas_eval.py` — switch between ragpipe (:8090) and ragorchestrator (:8095) without editing targets.yaml
- Created `scripts/compare_targets.py` — queries probe_results for two target labels, computes per-metric per-route deltas, prints a comparison table, and exits 1 on regression
- Updated `targets.yaml.example` with ragpipe-v1, ragorchestrator-crag, and ragorchestrator-full target templates
- Updated CLAUDE.md with comparison workflow documentation
- Added `ragprobe.db` to .gitignore

## Testing
16 unit tests covering:
- Helper functions (_avg, _delta_str, _is_regression)
- SQLite query paths (empty, single route, multiple routes)
- Comparison output (no regressions, regressions detected, threshold suppression, per-route)
- End-to-end pipeline (insert baseline + candidate, query, compare)

All 16 passing.

## CI
Added two new CI jobs:
- `validate-ragas-scripts` — syntax check all Python scripts
- `test-compare-targets` — run pytest on comparison tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added target comparison tool to measure performance differences across deployment targets.
  * Environment variable support for configuring target URLs.

* **Documentation**
  * Expanded guidance on running evaluations against multiple deployment targets.
  * Added instructions for comparing baseline vs candidate targets with regression detection and JSON output.

* **Tests**
  * Comprehensive test coverage for comparison validation and evaluation queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->