### PR TITLE
feat(ragprobe): add per-route breakdown to Ragas eval output (fixes #17)

### DIFF
--- a/ragas_eval.py
+++ b/ragas_eval.py
@@ -188,7 +188,7 @@ def run_eval(
 
 
 def print_summary(results: list[EvalResult]) -> None:
-    """Print aggregate scores."""
+    """Print aggregate and per-route scores."""
     n = len(results)
     if n == 0:
         print("No results to summarize.")
@@ -211,3 +211,23 @@ def print_summary(results: list[EvalResult]) -> None:
     print(f"  Answer Relevance:  {_fmt(avg_ar)}")
     print(f"  Context Precision: {_fmt(avg_cp)}")
     print(f"  Context Recall:    {_fmt(avg_cr)}")
+
+    by_route: dict[str, list[EvalResult]] = {}
+    for r in results:
+        route = r.routing or "unknown"
+        by_route.setdefault(route, []).append(r)
+
+    if len(by_route) > 1:
+        print("\nPer-Route Breakdown:")
+        for route, route_results in sorted(by_route.items()):
+            rn = len(route_results)
+
+            def route_avg(attr):
+                vals = [getattr(r, attr) for r in route_results if getattr(r, attr) is not None]
+                return sum(vals) / len(vals) if vals else None
+
+            print(f"  Route: {route} ({rn} pairs)")
+            print(f"    Faithfulness:      {_fmt(route_avg('faithfulness'))}")
+            print(f"    Answer Relevance:  {_fmt(route_avg('answer_relevance'))}")
+            print(f"    Context Precision: {_fmt(route_avg('context_precision'))}")
+            print(f"    Context Recall:    {_fmt(route_avg('context_recall'))}")

--- a/ragprobe.egg-info/SOURCES.txt
+++ b/ragprobe.egg-info/SOURCES.txt
@@ -8,3 +8,4 @@ ragprobe.egg-info/entry_points.txt
 ragprobe.egg-info/requires.txt
 ragprobe.egg-info/top_level.txt
 tests/test_compare_targets.py
+tests/test_ragas_eval.py

--- a/scripts/run_ragas_eval.py
+++ b/scripts/run_ragas_eval.py
@@ -235,7 +235,7 @@ def get_latest_scores(target_label: str) -> dict:
         row = cursor.fetchone()
         conn.close()
         if row and row[0] is not None:
-            return {
+            result = {
                 "faithfulness": row[0],
                 "answer_relevance": row[1],
                 "context_precision": row[2],
@@ -243,6 +243,36 @@ def get_latest_scores(target_label: str) -> dict:
                 "n": row[4],
                 "last_run": row[5],
             }
+
+            conn2 = sqlite3.connect(SQLITE_DB)
+            route_cursor = conn2.execute(
+                """
+                SELECT
+                    routing,
+                    AVG(faithfulness) as avg_f,
+                    AVG(answer_relevance) as avg_ar,
+                    AVG(context_precision) as avg_cp,
+                    AVG(context_recall) as avg_cr,
+                    COUNT(*) as n
+                FROM probe_results
+                WHERE target = ?
+                GROUP BY routing
+                """,
+                (target_label,),
+            )
+            by_route = {}
+            for route_row in route_cursor.fetchall():
+                routing = route_row[0] or "unknown"
+                by_route[routing] = {
+                    "faithfulness": route_row[1],
+                    "answer_relevance": route_row[2],
+                    "context_precision": route_row[3],
+                    "context_recall": route_row[4],
+                    "n": route_row[5],
+                }
+            conn2.close()
+            result["by_route"] = by_route
+            return result
     return {}
 
 
@@ -277,6 +307,15 @@ def main():
             print(f"  Answer Relevance:  {scores['answer_relevance']:.3f}")
             print(f"  Context Precision: {scores['context_precision']:.3f}")
             print(f"  Context Recall:    {scores['context_recall']:.3f}")
+            by_route = scores.get("by_route", {})
+            if len(by_route) > 1:
+                print("\nPer-Route Breakdown:")
+                for route, rs in sorted(by_route.items()):
+                    print(f"  Route: {route} ({rs['n']} pairs)")
+                    print(f"    Faithfulness:      {rs['faithfulness']:.3f}")
+                    print(f"    Answer Relevance:  {rs['answer_relevance']:.3f}")
+                    print(f"    Context Precision: {rs['context_precision']:.3f}")
+                    print(f"    Context Recall:    {rs['context_recall']:.3f}")
         else:
             print(f"No stored results for {args.target}")
         sys.exit(0)

--- a/tests/test_ragas_eval.py
+++ b/tests/test_ragas_eval.py
@@ -1,0 +1,123 @@
+"""Tests for ragas_eval.py print_summary per-route breakdown."""
+
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent.parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from ragas_eval import EvalResult, print_summary
+
+
+class TestPrintSummaryPerRoute:
+    def test_aggregate_only_when_single_route(self, capsys):
+        results = [
+            EvalResult(
+                eval_run_id="run1",
+                eval_run_at="2026-01-01T00:00:00Z",
+                target="test",
+                ragpipe_version=None,
+                model=None,
+                question="q1",
+                ground_truth="a1",
+                answer="a1",
+                context_chunks=[],
+                faithfulness=0.8,
+                answer_relevance=0.85,
+                context_precision=0.7,
+                context_recall=0.6,
+                routing="personnel",
+            ),
+        ]
+        print_summary(results)
+        output = capsys.readouterr().out
+        assert "Aggregate scores (1 eval pairs)" in output
+        assert "Per-Route Breakdown" not in output
+
+    def test_per_route_breakdown_when_multiple_routes(self, capsys):
+        results = [
+            EvalResult(
+                eval_run_id="run1",
+                eval_run_at="2026-01-01T00:00:00Z",
+                target="test",
+                ragpipe_version=None,
+                model=None,
+                question="q1",
+                ground_truth="a1",
+                answer="a1",
+                context_chunks=[],
+                faithfulness=0.9,
+                answer_relevance=0.85,
+                context_precision=0.7,
+                context_recall=0.6,
+                routing="personnel",
+            ),
+            EvalResult(
+                eval_run_id="run1",
+                eval_run_at="2026-01-01T00:00:00Z",
+                target="test",
+                ragpipe_version=None,
+                model=None,
+                question="q2",
+                ground_truth="a2",
+                answer="a2",
+                context_chunks=[],
+                faithfulness=0.3,
+                answer_relevance=0.6,
+                context_precision=0.5,
+                context_recall=0.4,
+                routing="lookup",
+            ),
+        ]
+        print_summary(results)
+        output = capsys.readouterr().out
+        assert "Per-Route Breakdown:" in output
+        assert "Route: lookup" in output
+        assert "Route: personnel" in output
+        assert "0.900" in output
+        assert "0.300" in output
+
+    def test_unknown_route_when_routing_none(self, capsys):
+        results = [
+            EvalResult(
+                eval_run_id="run1",
+                eval_run_at="2026-01-01T00:00:00Z",
+                target="test",
+                ragpipe_version=None,
+                model=None,
+                question="q1",
+                ground_truth="a1",
+                answer="a1",
+                context_chunks=[],
+                faithfulness=0.8,
+                answer_relevance=0.85,
+                context_precision=0.7,
+                context_recall=0.6,
+                routing=None,
+            ),
+            EvalResult(
+                eval_run_id="run1",
+                eval_run_at="2026-01-01T00:00:00Z",
+                target="test",
+                ragpipe_version=None,
+                model=None,
+                question="q2",
+                ground_truth="a2",
+                answer="a2",
+                context_chunks=[],
+                faithfulness=0.6,
+                answer_relevance=0.75,
+                context_precision=0.8,
+                context_recall=0.7,
+                routing="personnel",
+            ),
+        ]
+        print_summary(results)
+        output = capsys.readouterr().out
+        assert "Route: unknown" in output
+        assert "Route: personnel" in output
+
+    def test_empty_results(self, capsys):
+        print_summary([])
+        output = capsys.readouterr().out
+        assert "No results to summarize" in output


### PR DESCRIPTION
Closes #17

## Problem
Ragas evaluation only reported aggregate scores. The Phase 0 baseline showed dramatically different quality across routes (Personnel faithfulness 0.967 vs Lookup 0.333), making it hard to identify which routes improved or regressed after CRAG.

## Solution
- Updated `print_summary()` in `ragas_eval.py` to show per-route breakdown alongside aggregate scores (only when multiple routes present)
- Updated `get_latest_scores()` in `run_ragas_eval.py` to include `by_route` field from stored probe_results
- Updated `--latest` output to display per-route scores when available

## Testing
20 tests passing (4 new tests for per-route breakdown):
- `test_aggregate_only_when_single_route` - no per-route shown for single route
- `test_per_route_breakdown_when_multiple_routes` - verifies correct route names and scores
- `test_unknown_route_when_routing_none` - handles None routing gracefully
- `test_empty_results` - handles empty results

## Key design decisions
- Per-route breakdown only shown when multiple routes exist (avoids cluttering single-route output)
- Routes sorted alphabetically for consistent output
- `unknown` used when routing is None (consistent with compare_targets.py)

## Notes
- `compare_targets.py` already had per-route comparison and regression detection (from earlier work)
- Corpus routes (personnel, analysis, lookup, general) map to the semantic routes used by ragpipe