### PR TITLE
fix(ragprobe): remove PYTHONPATH workaround from run_ragas_eval.py (fixes #25)

### DIFF
--- a/scripts/run_ragas_eval.py
+++ b/scripts/run_ragas_eval.py
@@ -39,10 +39,6 @@ from dataclasses import asdict
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).parent.parent
-
-# Allow running scripts without pip install -e . by adding repo root to path
-if str(SCRIPT_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPT_DIR))
 DEFAULT_CORPUS = SCRIPT_DIR / "ragas" / "corpus.yaml"
 SQLITE_DB = SCRIPT_DIR / "ragprobe.db"
 


### PR DESCRIPTION
Closes #25

## Change
Removed redundant PYTHONPATH workaround from scripts/run_ragas_eval.py. The quickstart.sh script already handles package installation via Defaulting to user installation because normal site-packages is not writeable
Obtaining file:///home/aclater/git-work/25-remove-pythonpath-workaround/ragprobe
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: pyyaml>=6.0 in /usr/lib64/python3.14/site-packages (from ragprobe==0.1.0) (6.0.2)
Requirement already satisfied: ragas>=0.2.0 in /home/aclater/.local/lib/python3.14/site-packages (from ragprobe==0.1.0) (0.2.15)
Requirement already satisfied: psycopg2-binary>=2.9 in /home/aclater/.local/lib/python3.14/site-packages (from ragprobe==0.1.0) (2.9.11)
Requirement already satisfied: datasets>=2.14.0 in /home/aclater/.local/lib/python3.14/site-packages (from ragprobe==0.1.0) (4.8.4)
Requirement already satisfied: numpy>=1.24.0 in /home/aclater/.local/lib/python3.14/site-packages (from ragprobe==0.1.0) (2.4.3)
Requirement already satisfied: filelock in /home/aclater/.local/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (3.25.2)
Requirement already satisfied: pyarrow>=21.0.0 in /home/aclater/.local/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (23.0.1)
Requirement already satisfied: dill<0.4.2,>=0.3.0 in /home/aclater/.local/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (0.4.1)
Requirement already satisfied: pandas in /home/aclater/.local/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (2.3.3)
Requirement already satisfied: requests>=2.32.2 in /usr/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (2.32.5)
Requirement already satisfied: httpx<1.0.0 in /usr/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (0.28.1)
Requirement already satisfied: tqdm>=4.66.3 in /home/aclater/.local/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (4.67.3)
Requirement already satisfied: xxhash in /home/aclater/.local/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (3.6.0)
Requirement already satisfied: multiprocess<0.70.20 in /home/aclater/.local/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (0.70.19)
Requirement already satisfied: fsspec<=2026.2.0,>=2023.1.0 in /home/aclater/.local/lib/python3.14/site-packages (from fsspec[http]<=2026.2.0,>=2023.1.0->datasets>=2.14.0->ragprobe==0.1.0) (2026.2.0)
Requirement already satisfied: huggingface-hub<2.0,>=0.25.0 in /home/aclater/.local/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (1.8.0)
Requirement already satisfied: packaging in /home/aclater/.local/lib/python3.14/site-packages (from datasets>=2.14.0->ragprobe==0.1.0) (26.0)
Requirement already satisfied: aiohttp!=4.0.0a0,!=4.0.0a1 in /home/aclater/.local/lib/python3.14/site-packages (from fsspec[http]<=2026.2.0,>=2023.1.0->datasets>=2.14.0->ragprobe==0.1.0) (3.13.5)
Requirement already satisfied: anyio in /usr/lib/python3.14/site-packages (from httpx<1.0.0->datasets>=2.14.0->ragprobe==0.1.0) (4.12.1)
Requirement already satisfied: certifi in /usr/lib/python3.14/site-packages (from httpx<1.0.0->datasets>=2.14.0->ragprobe==0.1.0) (2025.7.9)
Requirement already satisfied: httpcore==1.* in /usr/lib/python3.14/site-packages (from httpx<1.0.0->datasets>=2.14.0->ragprobe==0.1.0) (1.0.9)
Requirement already satisfied: idna in /usr/lib/python3.14/site-packages (from httpx<1.0.0->datasets>=2.14.0->ragprobe==0.1.0) (3.10)
Requirement already satisfied: h11>=0.16 in /usr/lib/python3.14/site-packages (from httpcore==1.*->httpx<1.0.0->datasets>=2.14.0->ragprobe==0.1.0) (0.16.0)
Requirement already satisfied: hf-xet<2.0.0,>=1.4.2 in /home/aclater/.local/lib/python3.14/site-packages (from huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (1.4.3)
Requirement already satisfied: typer in /home/aclater/.local/lib/python3.14/site-packages (from huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (0.24.1)
Requirement already satisfied: typing-extensions>=4.1.0 in /usr/lib/python3.14/site-packages (from huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (4.15.0)
Requirement already satisfied: aiohappyeyeballs>=2.5.0 in /home/aclater/.local/lib/python3.14/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets>=2.14.0->ragprobe==0.1.0) (2.6.1)
Requirement already satisfied: aiosignal>=1.4.0 in /home/aclater/.local/lib/python3.14/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets>=2.14.0->ragprobe==0.1.0) (1.4.0)
Requirement already satisfied: attrs>=17.3.0 in /usr/lib/python3.14/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets>=2.14.0->ragprobe==0.1.0) (25.4.0)
Requirement already satisfied: frozenlist>=1.1.1 in /home/aclater/.local/lib/python3.14/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets>=2.14.0->ragprobe==0.1.0) (1.8.0)
Requirement already satisfied: multidict<7.0,>=4.5 in /home/aclater/.local/lib/python3.14/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets>=2.14.0->ragprobe==0.1.0) (6.7.1)
Requirement already satisfied: propcache>=0.2.0 in /home/aclater/.local/lib/python3.14/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets>=2.14.0->ragprobe==0.1.0) (0.4.1)
Requirement already satisfied: yarl<2.0,>=1.17.0 in /home/aclater/.local/lib/python3.14/site-packages (from aiohttp!=4.0.0a0,!=4.0.0a1->fsspec[http]<=2026.2.0,>=2023.1.0->datasets>=2.14.0->ragprobe==0.1.0) (1.23.0)
Requirement already satisfied: tiktoken in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (0.12.0)
Requirement already satisfied: langchain in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (1.2.15)
Requirement already satisfied: langchain-core in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (1.2.25)
Requirement already satisfied: langchain-community in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (0.4.1)
Requirement already satisfied: langchain_openai in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (1.1.12)
Requirement already satisfied: nest-asyncio in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (1.6.0)
Requirement already satisfied: appdirs in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (1.4.4)
Requirement already satisfied: pydantic>=2 in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (2.12.5)
Requirement already satisfied: openai>1 in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (2.30.0)
Requirement already satisfied: diskcache>=5.6.3 in /home/aclater/.local/lib/python3.14/site-packages (from ragas>=0.2.0->ragprobe==0.1.0) (5.6.3)
Requirement already satisfied: distro<2,>=1.7.0 in /usr/lib/python3.14/site-packages (from openai>1->ragas>=0.2.0->ragprobe==0.1.0) (1.9.0)
Requirement already satisfied: jiter<1,>=0.10.0 in /home/aclater/.local/lib/python3.14/site-packages (from openai>1->ragas>=0.2.0->ragprobe==0.1.0) (0.13.0)
Requirement already satisfied: sniffio in /usr/lib/python3.14/site-packages (from openai>1->ragas>=0.2.0->ragprobe==0.1.0) (1.3.1)
Requirement already satisfied: annotated-types>=0.6.0 in /home/aclater/.local/lib/python3.14/site-packages (from pydantic>=2->ragas>=0.2.0->ragprobe==0.1.0) (0.7.0)
Requirement already satisfied: pydantic-core==2.41.5 in /home/aclater/.local/lib/python3.14/site-packages (from pydantic>=2->ragas>=0.2.0->ragprobe==0.1.0) (2.41.5)
Requirement already satisfied: typing-inspection>=0.4.2 in /home/aclater/.local/lib/python3.14/site-packages (from pydantic>=2->ragas>=0.2.0->ragprobe==0.1.0) (0.4.2)
Requirement already satisfied: charset_normalizer<4,>=2 in /usr/lib/python3.14/site-packages (from requests>=2.32.2->datasets>=2.14.0->ragprobe==0.1.0) (3.4.3)
Requirement already satisfied: urllib3<3,>=1.21.1 in /usr/lib/python3.14/site-packages (from requests>=2.32.2->datasets>=2.14.0->ragprobe==0.1.0) (2.6.3)
Requirement already satisfied: langgraph<1.2.0,>=1.1.5 in /home/aclater/.local/lib/python3.14/site-packages (from langchain->ragas>=0.2.0->ragprobe==0.1.0) (1.1.6)
Requirement already satisfied: jsonpatch<2.0.0,>=1.33.0 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-core->ragas>=0.2.0->ragprobe==0.1.0) (1.33)
Requirement already satisfied: langsmith<1.0.0,>=0.3.45 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-core->ragas>=0.2.0->ragprobe==0.1.0) (0.7.24)
Requirement already satisfied: tenacity!=8.4.0,<10.0.0,>=8.1.0 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-core->ragas>=0.2.0->ragprobe==0.1.0) (9.1.4)
Requirement already satisfied: uuid-utils<1.0,>=0.12.0 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-core->ragas>=0.2.0->ragprobe==0.1.0) (0.14.1)
Requirement already satisfied: jsonpointer>=1.9 in /home/aclater/.local/lib/python3.14/site-packages (from jsonpatch<2.0.0,>=1.33.0->langchain-core->ragas>=0.2.0->ragprobe==0.1.0) (3.1.1)
Requirement already satisfied: langgraph-checkpoint<5.0.0,>=2.1.0 in /home/aclater/.local/lib/python3.14/site-packages (from langgraph<1.2.0,>=1.1.5->langchain->ragas>=0.2.0->ragprobe==0.1.0) (4.0.1)
Requirement already satisfied: langgraph-prebuilt<1.1.0,>=1.0.9 in /home/aclater/.local/lib/python3.14/site-packages (from langgraph<1.2.0,>=1.1.5->langchain->ragas>=0.2.0->ragprobe==0.1.0) (1.0.9)
Requirement already satisfied: langgraph-sdk<0.4.0,>=0.3.0 in /home/aclater/.local/lib/python3.14/site-packages (from langgraph<1.2.0,>=1.1.5->langchain->ragas>=0.2.0->ragprobe==0.1.0) (0.3.12)
Requirement already satisfied: ormsgpack>=1.12.0 in /home/aclater/.local/lib/python3.14/site-packages (from langgraph-checkpoint<5.0.0,>=2.1.0->langgraph<1.2.0,>=1.1.5->langchain->ragas>=0.2.0->ragprobe==0.1.0) (1.12.2)
Requirement already satisfied: orjson>=3.11.5 in /home/aclater/.local/lib/python3.14/site-packages (from langgraph-sdk<0.4.0,>=0.3.0->langgraph<1.2.0,>=1.1.5->langchain->ragas>=0.2.0->ragprobe==0.1.0) (3.11.8)
Requirement already satisfied: requests-toolbelt>=1.0.0 in /home/aclater/.local/lib/python3.14/site-packages (from langsmith<1.0.0,>=0.3.45->langchain-core->ragas>=0.2.0->ragprobe==0.1.0) (1.0.0)
Requirement already satisfied: zstandard>=0.23.0 in /home/aclater/.local/lib/python3.14/site-packages (from langsmith<1.0.0,>=0.3.45->langchain-core->ragas>=0.2.0->ragprobe==0.1.0) (0.25.0)
Requirement already satisfied: langchain-classic<2.0.0,>=1.0.0 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (1.0.3)
Requirement already satisfied: SQLAlchemy<3.0.0,>=1.4.0 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (2.0.49)
Requirement already satisfied: dataclasses-json<0.7.0,>=0.6.7 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (0.6.7)
Requirement already satisfied: pydantic-settings<3.0.0,>=2.10.1 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (2.13.1)
Requirement already satisfied: httpx-sse<1.0.0,>=0.4.0 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (0.4.3)
Requirement already satisfied: marshmallow<4.0.0,>=3.18.0 in /home/aclater/.local/lib/python3.14/site-packages (from dataclasses-json<0.7.0,>=0.6.7->langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (3.26.2)
Requirement already satisfied: typing-inspect<1,>=0.4.0 in /home/aclater/.local/lib/python3.14/site-packages (from dataclasses-json<0.7.0,>=0.6.7->langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (0.9.0)
Requirement already satisfied: langchain-text-splitters<2.0.0,>=1.1.1 in /home/aclater/.local/lib/python3.14/site-packages (from langchain-classic<2.0.0,>=1.0.0->langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (1.1.1)
Requirement already satisfied: python-dotenv>=0.21.0 in /usr/lib/python3.14/site-packages (from pydantic-settings<3.0.0,>=2.10.1->langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (1.1.0)
Requirement already satisfied: greenlet>=1 in /home/aclater/.local/lib/python3.14/site-packages (from SQLAlchemy<3.0.0,>=1.4.0->langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (3.3.2)
Requirement already satisfied: mypy-extensions>=0.3.0 in /home/aclater/.local/lib/python3.14/site-packages (from typing-inspect<1,>=0.4.0->dataclasses-json<0.7.0,>=0.6.7->langchain-community->ragas>=0.2.0->ragprobe==0.1.0) (1.1.0)
Requirement already satisfied: regex>=2022.1.18 in /usr/lib64/python3.14/site-packages (from tiktoken->ragas>=0.2.0->ragprobe==0.1.0) (2026.2.28)
Requirement already satisfied: python-dateutil>=2.8.2 in /usr/lib/python3.14/site-packages (from pandas->datasets>=2.14.0->ragprobe==0.1.0) (2.9.0.post0)
Requirement already satisfied: pytz>=2020.1 in /home/aclater/.local/lib/python3.14/site-packages (from pandas->datasets>=2.14.0->ragprobe==0.1.0) (2026.1.post1)
Requirement already satisfied: tzdata>=2022.7 in /home/aclater/.local/lib/python3.14/site-packages (from pandas->datasets>=2.14.0->ragprobe==0.1.0) (2026.1)
Requirement already satisfied: six>=1.5 in /usr/lib/python3.14/site-packages (from python-dateutil>=2.8.2->pandas->datasets>=2.14.0->ragprobe==0.1.0) (1.17.0)
Requirement already satisfied: click>=8.2.1 in /home/aclater/.local/lib/python3.14/site-packages (from typer->huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (8.3.1)
Requirement already satisfied: shellingham>=1.3.0 in /home/aclater/.local/lib/python3.14/site-packages (from typer->huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (1.5.4)
Requirement already satisfied: rich>=12.3.0 in /home/aclater/.local/lib/python3.14/site-packages (from typer->huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (14.3.3)
Requirement already satisfied: annotated-doc>=0.0.2 in /home/aclater/.local/lib/python3.14/site-packages (from typer->huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (0.0.4)
Requirement already satisfied: markdown-it-py>=2.2.0 in /home/aclater/.local/lib/python3.14/site-packages (from rich>=12.3.0->typer->huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (4.0.0)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /home/aclater/.local/lib/python3.14/site-packages (from rich>=12.3.0->typer->huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (2.20.0)
Requirement already satisfied: mdurl~=0.1 in /home/aclater/.local/lib/python3.14/site-packages (from markdown-it-py>=2.2.0->rich>=12.3.0->typer->huggingface-hub<2.0,>=0.25.0->datasets>=2.14.0->ragprobe==0.1.0) (0.1.2)
Building wheels for collected packages: ragprobe
  Building editable for ragprobe (pyproject.toml): started
  Building editable for ragprobe (pyproject.toml): finished with status 'done'
  Created wheel for ragprobe: filename=ragprobe-0.1.0-0.editable-py3-none-any.whl size=14970 sha256=39f67c9bb30679d875be73d4bb4b064cdda204aa47169d4f03ab15fb2cf03090
  Stored in directory: /tmp/pip-ephem-wheel-cache-gz0kt0p9/wheels/31/6c/90/ed6e8de15e381c9ce22adcb42d87215054bc2d9e6db9d193b9
Successfully built ragprobe
Installing collected packages: ragprobe
  Attempting uninstall: ragprobe
    Found existing installation: ragprobe 0.1.0
    Uninstalling ragprobe-0.1.0:
      Successfully uninstalled ragprobe-0.1.0
Successfully installed ragprobe-0.1.0, making the sys.path modification unnecessary.

## Testing
- Python syntax check: passed
- CI validates with py_compile on all Ragas scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and optimization. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->