### PR TITLE
docs: restructure README with linked table of contents (refs #33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,11 @@ Adversarial testing and autonomous prompt tuning agent for [ragpipe](https://git
 
 ![Architecture](architecture.svg)
 
-## What it tests
+## Table of contents
 
-| Category | Tests | What it probes |
-|----------|-------|----------------|
-| cross_source | 5 | Citing docs from wrong context |
-| hallucination | 6 | Fabricated sections, people, programs, quotes |
-| leading | 6 | False premises, fabricated prior statements |
-| injection | 9 | Jailbreaks, DAN, base64, YAML frontmatter, nested tags |
-| role_confusion | 4 | Developer/admin/researcher/red-team claims |
-| exfiltration | 4 | System prompt, infra details, corpus dump |
-| scope_creep | 4 | Topic drift, personal advice, creative writing |
-| temporal | 3 | Future predictions, staleness, false versions |
-| confidence | 3 | Overconfident premises, false precision |
-| context_poisoning | 2 | Fabricated conversation history |
-| corpus_boundary | 5 | Cite/add/delete/merge/rank documents |
-| multilingual | 12 | Same attacks in FR, ES, DE, ZH, AR, JA, RU, KO, PT, HI, TR, mixed |
-| boundary | 3 | Empty, unicode, vague queries |
-| **Total** | **66** | |
+- [Architecture](docs/architecture.md) — data flow, test categories, tuning agent loop
+- [Configuration](docs/configuration.md) — targets.yaml, tuning agent usage
+- [Ragas evaluation](docs/ragas-evaluation.md) — quantitative quality metrics and comparison
 
 ## Quick start
 
@@ -46,141 +33,15 @@ npx promptfoo view
 python agent.py
 ```
 
-## Configuration
-
-### targets.yaml (gitignored)
-
-Define ragpipe instances and agent settings:
-
-```yaml
-targets:
-  - label: primary-35b
-    url: http://host-a:8090
-    token: admin-token-a
-    model: qwen3.5
-  - label: secondary-9b
-    url: http://host-b:8090
-    token: admin-token-b
-    model: qwen3.5
-
-agent:
-  brain_url: http://host-b:8080    # local coder LLM (direct, not through ragpipe)
-  brain_model: qwen3.5
-  max_iterations: 5
-  target_pass_rate: 0.85
-  prompt_file: prompts/system-prompt.txt
-```
-
-## Tuning agent
-
-The agent runs a closed loop: test → analyze failures → generate improved prompt → reload → re-test → learn.
-
-```bash
-python agent.py                          # 5 iterations, 85% target
-python agent.py --max-iterations 1       # single iteration
-python agent.py --dry-run                # analyze only, don't modify
-python agent.py --target-pass-rate 0.90  # aim for 90%
-```
-
-### How it works
-
-1. Runs `npx promptfoo eval` and parses structured results
-2. Extracts failures by category with query, reason, and response preview
-3. Builds an analysis prompt with current prompt + failures + iteration history
-4. Calls a local coder LLM to generate an improved system prompt
-5. Writes the prompt and SCPs it to remote targets
-6. Calls `POST /admin/reload-prompt` on all ragpipe instances
-7. Re-runs eval to verify improvement
-8. **If improved**: keeps the prompt, logs success
-9. **If regressed**: reverts to previous prompt, logs failure
-10. Appends iteration to `history.json` so the brain learns from past attempts
-
-### Files
-
-| File | Purpose |
-|------|---------|
-| `agent.py` | Main tuning agent loop |
-| `prompts/system-prompt.txt` | Current best system prompt (committed) |
-| `history.json` | Iteration history for learning (gitignored) |
-
-## Manual testing
+## Running tests
 
 ```bash
 npx promptfoo eval                    # CLI table
 npx promptfoo eval -o results.json    # JSON
 npx promptfoo eval -o results.html    # HTML report
 npx promptfoo view                    # Interactive browser UI
-bash scripts/reload-and-eval.sh       # Reload prompts + eval
+bash scripts/reload-and-eval.sh      # Reload prompts + eval
 ```
-
-## Custom assertions
-
-Custom Python assertions in `assertions/grounding.py` check ragpipe-specific fields:
-
-- `check_grounding` — verifies grounding matches expected (corpus/general/mixed)
-- `check_no_citations` / `check_has_citations` — citation count validation
-- `check_has_warning` / `check_no_warning` — warning prefix presence
-- `check_is_refusal` — detects refusal markers in 12 languages
-- `check_not_refusal` — ensures non-refusal response
-
-## Ragas evaluation
-
-ragprobe includes quantitative RAG quality evaluation using [Ragas](https://github.com/explodinggradients/ragas). Ragas provides metrics beyond pass/fail adversarial tests:
-
-| Metric | What it measures |
-|--------|-----------------|
-| Faithfulness | Is the answer supported by the retrieved context? |
-| Answer relevance | Does the answer address the original question? |
-| Context precision | Of chunks retrieved, how many were useful? |
-| Context recall | Did retrieval find all needed chunks? |
-
-### How Ragas evaluation works
-
-1. Run promptfoo tests to get query/answer/context pairs
-2. Ragas evaluates each pair using a judge LLM
-3. Scores are stored in the `probe_results` table in Postgres
-4. Scores are surfaced in ragwatch and ragdeck
-
-### probe_results table
-
-```sql
-CREATE TABLE probe_results (
-    id SERIAL PRIMARY KEY,
-    run_id TEXT NOT NULL,
-    query TEXT NOT NULL,
-    answer TEXT NOT NULL,
-    contexts JSONB NOT NULL,
-    faithfulness FLOAT,
-    answer_relevance FLOAT,
-    context_precision FLOAT,
-    context_recall FLOAT,
-    ragas_score FLOAT,
-    evaluated_at TIMESTAMPTZ DEFAULT NOW()
-);
-```
-
-### Running Ragas evaluation
-
-```bash
-# Full Ragas evaluation pipeline (requires pip install -e .)
-python scripts/run_ragas_eval.py
-
-# The script:
-# 1. Runs promptfoo tests (npx promptfoo eval -o results.json)
-# 2. Parses results and extracts query/answer/contexts
-# 3. Calls Ragas to compute metrics
-# 4. Stores results in probe_results table
-```
-
-### Ragas files
-
-| File | Purpose |
-|------|---------|
-| `ragas_eval.py` | Main Ragas evaluation logic |
-| `ragas_metrics.py` | Ragas metric wrappers |
-| `scripts/run_ragas_eval.py` | CLI script to run full pipeline |
-| `ragas/corpus.yaml` | Test corpus for Ragas evaluation |
-| `tests/ragas_eval.yaml` | Ragas test configuration |
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,85 @@
+# Architecture
+
+Adversarial testing and autonomous prompt tuning agent for [ragpipe](https://github.com/aclater/ragpipe). Probes RAG grounding quality, citation accuracy, and safety under adversarial queries using [promptfoo](https://github.com/promptfoo/promptfoo), then iteratively improves ragpipe's system prompt using a local coder LLM.
+
+## Test categories
+
+| Category | Tests | What it probes |
+|----------|-------|----------------|
+| cross_source | 5 | Citing docs from wrong context |
+| hallucination | 6 | Fabricated sections, people, programs, quotes |
+| leading | 6 | False premises, fabricated prior statements |
+| injection | 9 | Jailbreaks, DAN, base64, YAML frontmatter, nested tags |
+| role_confusion | 4 | Developer/admin/researcher/red-team claims |
+| exfiltration | 4 | System prompt, infra details, corpus dump |
+| scope_creep | 4 | Topic drift, personal advice, creative writing |
+| temporal | 3 | Future predictions, staleness, false versions |
+| confidence | 3 | Overconfident premises, false precision |
+| context_poisoning | 2 | Fabricated conversation history |
+| corpus_boundary | 5 | Cite/add/delete/merge/rank documents |
+| multilingual | 12 | Same attacks in FR, ES, DE, ZH, AR, JA, RU, KO, PT, HI, TR, mixed |
+| boundary | 3 | Empty, unicode, vague queries |
+| **Total** | **66** | |
+
+## Tuning agent loop
+
+```
+agent.py loop:
+  1. npx promptfoo eval -o results.json
+  2. Parse failures by category (66 tests, 13 categories)
+  3. Build analysis prompt: current prompt + failures + history
+  4. Call local coder LLM (Qwen3-Coder-30B-A3B) for improved prompt
+  5. Write prompt + SCP to remote targets
+  6. POST /admin/reload-prompt on all targets
+  7. Re-run eval → compare
+  8. Keep if improved, revert if regressed
+  9. Append to history.json for learning
+```
+
+## Custom assertions
+
+Custom Python assertions in `assertions/grounding.py` check ragpipe-specific fields:
+
+- `check_grounding` — verifies grounding matches expected (corpus/general/mixed)
+- `check_no_citations` / `check_has_citations` — citation count validation
+- `check_has_warning` / `check_no_warning` — warning prefix presence
+- `check_is_refusal` — detects refusal markers in 12 languages
+- `check_not_refusal` — ensures non-refusal response
+
+## Metadata format
+
+Provider returns `{"output": content, "metadata": rag_metadata}`.
+Assertions access it via `context["providerResponse"]["metadata"]`.
+
+cited_chunks entries are objects with `id`, `title`, and `source`:
+```python
+cited_chunks = [
+    {"id": "abc-123:0", "title": "Q3 Strategy", "source": "gdrive://file.pdf"}
+]
+```
+
+Assertions should extract IDs:
+```python
+chunk_ids = [c["id"] for c in context["providerResponse"]["metadata"]["cited_chunks"]]
+```
+
+## Key files
+
+```
+agent.py                    — tuning loop (eval → brain → reload → verify)
+ragpipe_provider.py         — custom promptfoo provider returning rag_metadata
+assertions/grounding.py    — 7 assertion functions, 40+ multilingual refusal markers
+promptfooconfig.js          — dynamic provider list from targets.yaml
+prompts/system-prompt.txt   — current best prompt (committed)
+targets.yaml                — gitignored, real URLs + tokens + agent config
+history.json                — gitignored, iteration history for learning
+tests/*.yaml                — 13 test files, 66 adversarial tests
+scripts/smoke-test.sh        — stack verification in under 60 seconds
+scripts/reload-and-eval.sh  — manual reload + eval
+```
+
+## Prompt constraints
+
+Brain is instructed to keep prompts under 800 chars. Oversized prompts
+(>2000 chars) are truncated in code. The prompt must include citation
+format [doc_id:chunk_id] and warning prefix rules.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,45 @@
+# Configuration
+
+## targets.yaml (gitignored)
+
+Define ragpipe instances and agent settings:
+
+```yaml
+targets:
+  - label: primary-35b
+    url: http://host-a:8090
+    token: admin-token-a
+    model: qwen3.5
+  - label: secondary-9b
+    url: http://host-b:8090
+    token: admin-token-b
+    model: qwen3.5
+
+agent:
+  brain_url: http://host-b:8080    # local coder LLM (direct, not through ragpipe)
+  brain_model: qwen3.5
+  max_iterations: 5
+  target_pass_rate: 0.85
+  prompt_file: prompts/system-prompt.txt
+```
+
+## Tuning agent
+
+The agent runs a closed loop: test → analyze failures → generate improved prompt → reload → re-test → learn.
+
+```bash
+python agent.py                          # 5 iterations, 85% target
+python agent.py --max-iterations 1       # single iteration
+python agent.py --dry-run                # analyze only, don't modify
+python agent.py --target-pass-rate 0.90  # aim for 90%
+```
+
+## Manual testing
+
+```bash
+npx promptfoo eval                    # CLI table
+npx promptfoo eval -o results.json    # JSON
+npx promptfoo eval -o results.html   # HTML report
+npx promptfoo view                    # Interactive browser UI
+bash scripts/reload-and-eval.sh       # Reload prompts + eval
+```

--- a/docs/ragas-evaluation.md
+++ b/docs/ragas-evaluation.md
@@ -1,0 +1,74 @@
+# Ragas evaluation
+
+ragprobe includes quantitative RAG quality evaluation using [Ragas](https://github.com/explodinggradients/ragas). Ragas provides metrics beyond pass/fail adversarial tests:
+
+| Metric | What it measures |
+|--------|-----------------|
+| Faithfulness | Is the answer supported by the retrieved context? |
+| Answer relevance | Does the answer address the original question? |
+| Context precision | Of chunks retrieved, how many were useful? |
+| Context recall | Did retrieval find all needed chunks? |
+
+## How Ragas evaluation works
+
+1. Run promptfoo tests to get query/answer/context pairs
+2. Ragas evaluates each pair using a judge LLM
+3. Scores are stored in the `probe_results` table in Postgres
+4. Scores are surfaced in ragwatch and ragdeck
+
+## probe_results table
+
+```sql
+CREATE TABLE probe_results (
+    id SERIAL PRIMARY KEY,
+    run_id TEXT NOT NULL,
+    query TEXT NOT NULL,
+    answer TEXT NOT NULL,
+    contexts JSONB NOT NULL,
+    faithfulness FLOAT,
+    answer_relevance FLOAT,
+    context_precision FLOAT,
+    context_recall FLOAT,
+    ragas_score FLOAT,
+    evaluated_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+## Running Ragas evaluation
+
+```bash
+# Against ragpipe (non-agentic)
+RAGPROBE_TARGET_URL=http://localhost:8090 python scripts/run_ragas_eval.py --store --target ragpipe-v1
+
+# Against ragorchestrator (agentic with CRAG)
+RAGPROBE_TARGET_URL=http://localhost:8095 python scripts/run_ragas_eval.py --store --target ragorchestrator-crag
+
+# Against ragorchestrator (agentic full loop)
+RAGPROBE_TARGET_URL=http://localhost:8095 python scripts/run_ragas_eval.py --store --target ragorchestrator-full
+```
+
+## Comparing targets
+
+```bash
+# Compare agentic vs non-agentic
+python scripts/compare_targets.py --baseline ragpipe-v1 --target ragorchestrator-crag
+
+# With regression threshold (ignore deltas < 0.05)
+python scripts/compare_targets.py --baseline baseline --target crag-v1 --threshold 0.05
+
+# JSON output for automation
+python scripts/compare_targets.py --baseline ragpipe-v1 --target ragorchestrator-crag --json
+```
+
+Exit code 1 if regressions detected. Per-route breakdown flags which specific routes regressed. Use this to prove agentic loop improves quality.
+
+## Key files
+
+| File | Purpose |
+|------|---------|
+| `ragas_eval.py` | Main Ragas evaluation logic |
+| `ragas_metrics.py` | Ragas metric wrappers |
+| `scripts/run_ragas_eval.py` | CLI script to run full pipeline |
+| `scripts/compare_targets.py` | Compare scores between two targets |
+| `ragas/corpus.yaml` | Test corpus for Ragas evaluation |
+| `tests/test_compare_targets.py` | Unit tests for comparison logic |


### PR DESCRIPTION
Closes #33

## Problem

README had all documentation inline (187 lines), making it difficult to navigate.

## Solution

- Created docs/ directory with structured documentation:
  - docs/architecture.md — data flow, test categories, tuning agent loop
  - docs/configuration.md — targets.yaml, tuning agent usage
  - docs/ragas-evaluation.md — quantitative quality metrics and comparison
- Updated README.md to have linked table of contents and concise quick-start

## Testing

N/A — documentation only