### PR TITLE
docs: update architecture.svg for current ragprobe state

### DIFF
--- a/architecture.svg
+++ b/architecture.svg
@@ -1,18 +1,23 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 520" font-family="system-ui, -apple-system, sans-serif" font-size="13">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 680" font-family="system-ui, -apple-system, sans-serif" font-size="13">
   <style>
     @media (prefers-color-scheme: dark) {
       .bg { fill: #1a1a2e; }
       .box { fill: #16213e; stroke: #e2e8f0; }
       .box-highlight { fill: #1a365d; stroke: #63b3ed; }
       .box-external { fill: #1c1c1c; stroke: #718096; }
+      .box-target { fill: #1a2e1a; stroke: #68d391; }
+      .box-proposed { fill: #16213e; stroke: #a78bfa; stroke-dasharray: 6,3; }
+      .box-db { fill: #2d1a1a; stroke: #fc8181; }
       .text { fill: #e2e8f0; }
       .text-dim { fill: #a0aec0; }
       .text-accent { fill: #63b3ed; }
       .text-green { fill: #68d391; }
       .text-red { fill: #fc8181; }
+      .text-purple { fill: #b794f4; }
       .arrow { stroke: #63b3ed; fill: #63b3ed; }
       .arrow-green { stroke: #68d391; fill: #68d391; }
       .arrow-red { stroke: #fc8181; fill: #fc8181; }
+      .arrow-purple { stroke: #b794f4; fill: #b794f4; }
       .label-bg { fill: #2d3748; }
     }
     @media (prefers-color-scheme: light) {
@@ -20,14 +25,19 @@
       .box { fill: #f7fafc; stroke: #2d3748; }
       .box-highlight { fill: #ebf8ff; stroke: #3182ce; }
       .box-external { fill: #f9f9f9; stroke: #a0aec0; }
+      .box-target { fill: #f0fff4; stroke: #38a169; }
+      .box-proposed { fill: #faf5ff; stroke: #805ad5; stroke-dasharray: 6,3; }
+      .box-db { fill: #fff5f5; stroke: #c53030; }
       .text { fill: #1a202c; }
       .text-dim { fill: #718096; }
       .text-accent { fill: #2b6cb0; }
       .text-green { fill: #276749; }
       .text-red { fill: #c53030; }
+      .text-purple { fill: #6b46c1; }
       .arrow { stroke: #3182ce; fill: #3182ce; }
       .arrow-green { stroke: #38a169; fill: #38a169; }
       .arrow-red { stroke: #e53e3e; fill: #e53e3e; }
+      .arrow-purple { stroke: #805ad5; fill: #805ad5; }
       .label-bg { fill: #edf2f7; }
     }
   </style>
@@ -35,126 +45,210 @@
     <marker id="ah" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow"/></marker>
     <marker id="ahg" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow-green"/></marker>
     <marker id="ahr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow-red"/></marker>
+    <marker id="ahp" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto"><polygon points="0 0, 8 3, 0 6" class="arrow-purple"/></marker>
   </defs>
 
-  <rect width="800" height="520" class="bg" rx="8"/>
+  <rect width="800" height="680" class="bg" rx="8"/>
 
   <!-- Title -->
-  <text x="400" y="30" text-anchor="middle" font-size="18" font-weight="bold" class="text">ragprobe — adversarial tuning loop</text>
-  <text x="400" y="48" text-anchor="middle" font-size="11" class="text-dim">Closed-loop prompt improvement via local coder LLM</text>
+  <text x="400" y="28" text-anchor="middle" font-size="18" font-weight="bold" class="text">ragprobe architecture</text>
+  <text x="400" y="46" text-anchor="middle" font-size="11" class="text-dim">Adversarial testing + Ragas evaluation + autonomous tuning</text>
 
-  <!-- Step 1: Run eval -->
-  <rect x="30" y="70" width="180" height="50" rx="5" class="box"/>
-  <text x="120" y="93" text-anchor="middle" font-weight="600" font-size="12" class="text">1. Run eval</text>
-  <text x="120" y="109" text-anchor="middle" font-size="10" class="text-dim">npx promptfoo eval</text>
+  <!-- ============================================================ -->
+  <!-- LEFT COLUMN: Test suite + promptfoo engine                    -->
+  <!-- ============================================================ -->
 
-  <!-- Step 2: Analyze -->
-  <rect x="30" y="140" width="180" height="50" rx="5" class="box"/>
-  <text x="120" y="163" text-anchor="middle" font-weight="600" font-size="12" class="text">2. Analyze failures</text>
-  <text x="120" y="179" text-anchor="middle" font-size="10" class="text-dim">66 tests · 13 categories</text>
+  <!-- Test suite -->
+  <rect x="20" y="64" width="200" height="220" rx="6" class="box"/>
+  <text x="120" y="86" text-anchor="middle" font-weight="600" font-size="13" class="text">Adversarial test suite</text>
+  <text x="120" y="102" text-anchor="middle" font-size="10" class="text-dim">66 tests across 13 categories</text>
+  <text x="32" y="122" font-size="9" class="text-dim">injection (9)</text>
+  <text x="32" y="135" font-size="9" class="text-dim">multilingual (12)</text>
+  <text x="32" y="148" font-size="9" class="text-dim">hallucination (6)</text>
+  <text x="32" y="161" font-size="9" class="text-dim">leading (6)</text>
+  <text x="32" y="174" font-size="9" class="text-dim">cross_source (5)</text>
+  <text x="32" y="187" font-size="9" class="text-dim">corpus_bound (5)</text>
+  <text x="120" y="122" font-size="9" class="text-dim">exfiltration (4)</text>
+  <text x="120" y="135" font-size="9" class="text-dim">role_confusion (4)</text>
+  <text x="120" y="148" font-size="9" class="text-dim">scope_creep (4)</text>
+  <text x="120" y="161" font-size="9" class="text-dim">boundary (3)</text>
+  <text x="120" y="174" font-size="9" class="text-dim">temporal (3)</text>
+  <text x="120" y="187" font-size="9" class="text-dim">confidence (3)</text>
+  <text x="120" y="200" font-size="9" class="text-dim">context_poison (2)</text>
+  <text x="32" y="224" font-size="9" class="text-accent">Custom assertions:</text>
+  <text x="32" y="238" font-size="9" class="text-dim">grounding | citations | refusal</text>
+  <text x="32" y="252" font-size="9" class="text-dim">warning | 12-language markers</text>
+  <text x="32" y="268" font-size="9" class="text-dim">assertions/grounding.py</text>
 
-  <!-- Step 3: Brain -->
-  <rect x="30" y="210" width="180" height="50" rx="5" class="box-highlight" stroke-width="2"/>
-  <text x="120" y="233" text-anchor="middle" font-weight="600" font-size="12" class="text-accent">3. Call brain</text>
-  <text x="120" y="249" text-anchor="middle" font-size="10" class="text-dim">Qwen3-Coder-30B-A3B</text>
+  <!-- promptfoo engine -->
+  <rect x="20" y="300" width="200" height="60" rx="6" class="box-highlight" stroke-width="2"/>
+  <text x="120" y="323" text-anchor="middle" font-weight="600" font-size="13" class="text-accent">promptfoo</text>
+  <text x="120" y="340" text-anchor="middle" font-size="10" class="text-dim">npx promptfoo eval (Node.js)</text>
+  <text x="120" y="353" text-anchor="middle" font-size="10" class="text-dim">ragpipe_provider.py</text>
 
-  <!-- Step 4: Write + reload -->
-  <rect x="30" y="280" width="180" height="50" rx="5" class="box"/>
-  <text x="120" y="303" text-anchor="middle" font-weight="600" font-size="12" class="text">4. Write + reload</text>
-  <text x="120" y="319" text-anchor="middle" font-size="10" class="text-dim">SCP + /admin/reload-prompt</text>
+  <!-- Arrow: tests feed into promptfoo -->
+  <line x1="120" y1="284" x2="120" y2="300" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
 
-  <!-- Step 5: Re-eval -->
-  <rect x="30" y="350" width="180" height="50" rx="5" class="box"/>
-  <text x="120" y="373" text-anchor="middle" font-weight="600" font-size="12" class="text">5. Re-run eval</text>
-  <text x="120" y="389" text-anchor="middle" font-size="10" class="text-dim">Compare before/after</text>
+  <!-- ============================================================ -->
+  <!-- CENTER: Dual targets                                          -->
+  <!-- ============================================================ -->
 
-  <!-- Arrows between steps -->
-  <line x1="120" y1="120" x2="120" y2="140" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <line x1="120" y1="190" x2="120" y2="210" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <line x1="120" y1="260" x2="120" y2="280" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <line x1="120" y1="330" x2="120" y2="350" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <!-- ragpipe target -->
+  <rect x="280" y="64" width="170" height="70" rx="6" class="box-target"/>
+  <text x="365" y="87" text-anchor="middle" font-weight="600" font-size="13" class="text-green">ragpipe</text>
+  <text x="365" y="103" text-anchor="middle" font-size="11" class="text-dim">:8090 (plain RAG)</text>
+  <text x="365" y="118" text-anchor="middle" font-size="9" class="text-dim">/v1/chat/completions</text>
+  <text x="365" y="130" text-anchor="middle" font-size="9" class="text-dim">rag_metadata in response</text>
 
-  <!-- Decision: improved or regressed -->
-  <rect x="30" y="420" width="85" height="40" rx="5" class="box"/>
-  <text x="72" y="440" text-anchor="middle" font-size="11" class="text-green">Keep</text>
-  <text x="72" y="454" text-anchor="middle" font-size="9" class="text-dim">improved</text>
+  <!-- ragorchestrator target -->
+  <rect x="280" y="150" width="170" height="70" rx="6" class="box-target"/>
+  <text x="365" y="173" text-anchor="middle" font-weight="600" font-size="13" class="text-green">ragorchestrator</text>
+  <text x="365" y="189" text-anchor="middle" font-size="11" class="text-dim">:8095 (agentic RAG)</text>
+  <text x="365" y="204" text-anchor="middle" font-size="9" class="text-dim">CRAG + Self-RAG reflection</text>
+  <text x="365" y="216" text-anchor="middle" font-size="9" class="text-dim">multi-pass retrieval</text>
 
-  <rect x="125" y="420" width="85" height="40" rx="5" class="box"/>
-  <text x="167" y="440" text-anchor="middle" font-size="11" class="text-red">Revert</text>
-  <text x="167" y="454" text-anchor="middle" font-size="9" class="text-dim">regressed</text>
+  <!-- Arrows: promptfoo → targets -->
+  <line x1="220" y1="315" x2="280" y2="110" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <line x1="220" y1="335" x2="280" y2="190" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <text x="240" y="200" font-size="9" class="text-dim" transform="rotate(-55, 240, 200)">queries</text>
 
-  <line x1="80" y1="400" x2="72" y2="420" class="arrow-green" stroke-width="1.5" marker-end="url(#ahg)"/>
-  <line x1="160" y1="400" x2="167" y2="420" class="arrow-red" stroke-width="1.5" marker-end="url(#ahr)"/>
+  <!-- ============================================================ -->
+  <!-- CENTER: Results + Ragas evaluation                            -->
+  <!-- ============================================================ -->
 
-  <!-- Loop arrow back to step 1 -->
-  <path d="M 72 460 L 72 480 L 10 480 L 10 85 L 30 85" fill="none" class="arrow-green" stroke-width="1.5" marker-end="url(#ahg)"/>
-  <text x="10" y="290" font-size="9" class="text-green" transform="rotate(-90, 10, 290)">next iteration</text>
+  <!-- Results from promptfoo -->
+  <rect x="280" y="250" width="170" height="50" rx="5" class="box"/>
+  <text x="365" y="271" text-anchor="middle" font-weight="600" font-size="12" class="text">results.json</text>
+  <text x="365" y="287" text-anchor="middle" font-size="10" class="text-dim">per-test pass/fail + metadata</text>
 
-  <!-- Right side: what the agent interacts with -->
+  <!-- Arrow: promptfoo → results -->
+  <line x1="220" y1="340" x2="280" y2="275" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
 
-  <!-- ragpipe targets -->
-  <rect x="320" y="70" width="210" height="100" rx="6" class="box-external"/>
-  <text x="425" y="95" text-anchor="middle" font-weight="600" font-size="13" class="text">ragpipe targets</text>
-  <text x="425" y="115" text-anchor="middle" font-size="10" class="text-dim">N instances from targets.yaml</text>
-  <text x="425" y="133" text-anchor="middle" font-size="10" class="text-dim">/v1/chat/completions · /admin/reload-prompt</text>
-  <text x="425" y="151" text-anchor="middle" font-size="10" class="text-dim">rag_metadata in every response</text>
+  <!-- Ragas evaluation -->
+  <rect x="280" y="320" width="170" height="100" rx="6" class="box-highlight" stroke-width="2"/>
+  <text x="365" y="343" text-anchor="middle" font-weight="600" font-size="13" class="text-accent">Ragas evaluation</text>
+  <text x="365" y="360" text-anchor="middle" font-size="10" class="text-dim">ragas_eval.py</text>
+  <text x="295" y="380" font-size="10" class="text-dim">faithfulness</text>
+  <text x="295" y="394" font-size="10" class="text-dim">answer_relevance</text>
+  <text x="295" y="408" font-size="10" class="text-dim">context_precision</text>
+  <text x="380" y="380" font-size="10" class="text-dim">context_recall</text>
+  <text x="380" y="394" font-size="10" class="text-dim">ragas_score</text>
 
-  <!-- Arrow: eval → ragpipe -->
-  <line x1="210" y1="95" x2="320" y2="120" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <!-- Arrow: reload → ragpipe -->
-  <line x1="210" y1="305" x2="320" y2="140" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <!-- Arrow: results → ragas -->
+  <line x1="365" y1="300" x2="365" y2="320" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
 
-  <!-- Brain LLM -->
-  <rect x="320" y="210" width="210" height="70" rx="6" class="box-highlight" stroke-width="2"/>
-  <text x="425" y="237" text-anchor="middle" font-weight="bold" font-size="13" class="text-accent">Coder LLM</text>
-  <text x="425" y="255" text-anchor="middle" font-size="10" class="text-dim">Qwen3-Coder-30B-A3B</text>
-  <text x="425" y="270" text-anchor="middle" font-size="10" class="text-dim">Direct :8080 (not through ragpipe)</text>
+  <!-- ============================================================ -->
+  <!-- RIGHT COLUMN: Storage + comparison                            -->
+  <!-- ============================================================ -->
 
-  <!-- Arrow: brain call -->
-  <line x1="210" y1="235" x2="320" y2="245" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <!-- Postgres -->
+  <rect x="510" y="64" width="270" height="80" rx="6" class="box-db"/>
+  <text x="645" y="87" text-anchor="middle" font-weight="600" font-size="13" class="text-red">Postgres :5432</text>
+  <text x="645" y="105" text-anchor="middle" font-size="10" class="text-dim">probe_results table</text>
+  <text x="645" y="120" text-anchor="middle" font-size="9" class="text-dim">run_id | query | answer | contexts</text>
+  <text x="645" y="133" text-anchor="middle" font-size="9" class="text-dim">faithfulness | answer_relevance | context_*</text>
 
-  <!-- Prompt file -->
-  <rect x="320" y="310" width="210" height="50" rx="5" class="box"/>
-  <text x="425" y="333" text-anchor="middle" font-weight="600" font-size="12" class="text">prompts/system-prompt.txt</text>
-  <text x="425" y="349" text-anchor="middle" font-size="10" class="text-dim">Written by agent · read by ragpipe</text>
+  <!-- Arrow: ragas → postgres -->
+  <line x1="450" y1="370" x2="510" y2="120" class="arrow-red" stroke-width="1.5" marker-end="url(#ahr)"/>
+  <text x="488" y="230" font-size="9" class="text-dim" transform="rotate(-65, 488, 230)">--store</text>
 
-  <!-- Arrow: write prompt -->
-  <line x1="210" y1="310" x2="320" y2="335" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
+  <!-- compare_targets.py -->
+  <rect x="510" y="160" width="270" height="90" rx="6" class="box"/>
+  <text x="645" y="183" text-anchor="middle" font-weight="600" font-size="12" class="text">compare_targets.py</text>
+  <text x="645" y="200" text-anchor="middle" font-size="10" class="text-dim">Per-route regression detection</text>
+  <text x="645" y="218" text-anchor="middle" font-size="9" class="text-dim">--baseline ragpipe-v1 --target ragorchestrator-crag</text>
+  <text x="645" y="234" text-anchor="middle" font-size="9" class="text-dim">Exit 1 on regression | --threshold 0.05</text>
+  <text x="645" y="246" text-anchor="middle" font-size="9" class="text-dim">JSON output for CI automation</text>
 
-  <!-- History -->
-  <rect x="320" y="390" width="210" height="50" rx="5" class="box"/>
-  <text x="425" y="413" text-anchor="middle" font-weight="600" font-size="12" class="text">history.json</text>
-  <text x="425" y="429" text-anchor="middle" font-size="10" class="text-dim">Iteration log · fed to brain as context</text>
+  <!-- Arrow: postgres → compare -->
+  <line x1="645" y1="144" x2="645" y2="160" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
 
-  <!-- Arrow: history write -->
-  <line x1="167" y1="460" x2="320" y2="415" class="arrow" stroke-width="1.5" marker-end="url(#ah)"/>
-  <!-- Arrow: history read -->
-  <line x1="425" y1="390" x2="425" y2="280" class="arrow" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#ah)"/>
-  <text x="440" y="340" font-size="9" class="text-dim">feeds back</text>
+  <!-- ============================================================ -->
+  <!-- BOTTOM: Tuning agent loop (proposed — dotted)                 -->
+  <!-- ============================================================ -->
 
-  <!-- Test suite box -->
-  <rect x="580" y="70" width="190" height="200" rx="6" class="box"/>
-  <text x="675" y="95" text-anchor="middle" font-weight="600" font-size="13" class="text">Test suite</text>
-  <text x="675" y="115" text-anchor="middle" font-size="10" class="text-dim">66 tests · 13 categories</text>
-  <text x="590" y="138" font-size="9" class="text-dim">cross_source (5)</text>
-  <text x="590" y="152" font-size="9" class="text-dim">hallucination (6)</text>
-  <text x="590" y="166" font-size="9" class="text-dim">leading (6)</text>
-  <text x="590" y="180" font-size="9" class="text-dim">injection (9)</text>
-  <text x="590" y="194" font-size="9" class="text-dim">role_confusion (4)</text>
-  <text x="590" y="208" font-size="9" class="text-dim">exfiltration (4)</text>
-  <text x="590" y="222" font-size="9" class="text-dim">scope_creep (4)</text>
-  <text x="700" y="138" font-size="9" class="text-dim">temporal (3)</text>
-  <text x="700" y="152" font-size="9" class="text-dim">confidence (3)</text>
-  <text x="700" y="166" font-size="9" class="text-dim">context_poison (2)</text>
-  <text x="700" y="180" font-size="9" class="text-dim">corpus_bound (5)</text>
-  <text x="700" y="194" font-size="9" class="text-dim">multilingual (12)</text>
-  <text x="700" y="208" font-size="9" class="text-dim">boundary (3)</text>
-  <text x="590" y="252" font-size="9" class="text-dim">Custom assertions:</text>
-  <text x="590" y="264" font-size="9" class="text-dim">grounding · citations · refusal (12 langs)</text>
+  <rect x="20" y="440" width="760" height="225" rx="8" class="box-proposed" stroke-width="2"/>
+  <text x="400" y="462" text-anchor="middle" font-weight="bold" font-size="14" class="text-purple">Tuning agent loop (agent.py)</text>
+  <text x="400" y="478" text-anchor="middle" font-size="10" class="text-dim">Closed-loop prompt improvement via local coder LLM</text>
 
-  <!-- Arrow: eval uses tests -->
-  <line x1="530" y1="120" x2="580" y2="120" class="arrow" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#ah)"/>
+  <!-- Step boxes inside the loop -->
+  <!-- 1. Eval -->
+  <rect x="40" y="494" width="120" height="44" rx="4" class="box"/>
+  <text x="100" y="514" text-anchor="middle" font-weight="600" font-size="11" class="text">1. Run eval</text>
+  <text x="100" y="530" text-anchor="middle" font-size="9" class="text-dim">promptfoo eval</text>
+
+  <!-- 2. Analyze -->
+  <rect x="180" y="494" width="120" height="44" rx="4" class="box"/>
+  <text x="240" y="514" text-anchor="middle" font-weight="600" font-size="11" class="text">2. Analyze</text>
+  <text x="240" y="530" text-anchor="middle" font-size="9" class="text-dim">parse failures</text>
+
+  <!-- 3. Brain -->
+  <rect x="320" y="494" width="140" height="44" rx="4" class="box-highlight"/>
+  <text x="390" y="514" text-anchor="middle" font-weight="600" font-size="11" class="text-accent">3. Call brain</text>
+  <text x="390" y="530" text-anchor="middle" font-size="9" class="text-dim">Qwen3-Coder-30B-A3B</text>
+
+  <!-- 4. Write + reload -->
+  <rect x="480" y="494" width="130" height="44" rx="4" class="box"/>
+  <text x="545" y="514" text-anchor="middle" font-weight="600" font-size="11" class="text">4. Write + reload</text>
+  <text x="545" y="530" text-anchor="middle" font-size="9" class="text-dim">/admin/reload-prompt</text>
+
+  <!-- 5. Re-eval -->
+  <rect x="630" y="494" width="130" height="44" rx="4" class="box"/>
+  <text x="695" y="514" text-anchor="middle" font-weight="600" font-size="11" class="text">5. Re-eval</text>
+  <text x="695" y="530" text-anchor="middle" font-size="9" class="text-dim">compare before/after</text>
+
+  <!-- Arrows between agent steps -->
+  <line x1="160" y1="516" x2="180" y2="516" class="arrow-purple" stroke-width="1.5" marker-end="url(#ahp)"/>
+  <line x1="300" y1="516" x2="320" y2="516" class="arrow-purple" stroke-width="1.5" marker-end="url(#ahp)"/>
+  <line x1="460" y1="516" x2="480" y2="516" class="arrow-purple" stroke-width="1.5" marker-end="url(#ahp)"/>
+  <line x1="610" y1="516" x2="630" y2="516" class="arrow-purple" stroke-width="1.5" marker-end="url(#ahp)"/>
+
+  <!-- Decision: keep or revert -->
+  <rect x="40" y="560" width="100" height="36" rx="4" class="box"/>
+  <text x="90" y="578" text-anchor="middle" font-size="11" class="text-green">Keep</text>
+  <text x="90" y="592" text-anchor="middle" font-size="8" class="text-dim">improved</text>
+
+  <rect x="155" y="560" width="100" height="36" rx="4" class="box"/>
+  <text x="205" y="578" text-anchor="middle" font-size="11" class="text-red">Revert</text>
+  <text x="205" y="592" text-anchor="middle" font-size="8" class="text-dim">regressed</text>
+
+  <line x1="660" y1="538" x2="90" y2="560" class="arrow-green" stroke-width="1" marker-end="url(#ahg)"/>
+  <line x1="730" y1="538" x2="205" y2="560" class="arrow-red" stroke-width="1" marker-end="url(#ahr)"/>
+
+  <!-- Loop arrow -->
+  <path d="M 90 596 L 90 616 L 30 616 L 30 510 L 40 510" fill="none" class="arrow-green" stroke-width="1.5" marker-end="url(#ahg)"/>
+  <text x="30" y="568" font-size="8" class="text-green" transform="rotate(-90, 30, 568)">next iteration</text>
+
+  <!-- Artifacts inside loop -->
+  <rect x="310" y="560" width="140" height="36" rx="4" class="box"/>
+  <text x="380" y="577" text-anchor="middle" font-size="10" class="text">prompts/system-prompt.txt</text>
+  <text x="380" y="590" text-anchor="middle" font-size="8" class="text-dim">written by agent</text>
+
+  <rect x="470" y="560" width="120" height="36" rx="4" class="box"/>
+  <text x="530" y="577" text-anchor="middle" font-size="10" class="text">history.json</text>
+  <text x="530" y="590" text-anchor="middle" font-size="8" class="text-dim">iteration log</text>
+
+  <rect x="610" y="560" width="155" height="36" rx="4" class="box-highlight"/>
+  <text x="687" y="577" text-anchor="middle" font-size="10" class="text-accent">Coder LLM :8080</text>
+  <text x="687" y="590" text-anchor="middle" font-size="8" class="text-dim">direct (not through ragpipe)</text>
+
+  <!-- Arrows: step 3 → coder LLM, step 4 → prompt file -->
+  <line x1="390" y1="538" x2="687" y2="560" class="arrow-purple" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#ahp)"/>
+  <line x1="545" y1="538" x2="380" y2="560" class="arrow-purple" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#ahp)"/>
+
+  <!-- CI integration label (proposed) -->
+  <rect x="510" y="270" width="270" height="50" rx="5" class="box-proposed" stroke-width="1.5"/>
+  <text x="645" y="290" text-anchor="middle" font-weight="600" font-size="11" class="text-purple">CI integration (proposed)</text>
+  <text x="645" y="306" text-anchor="middle" font-size="9" class="text-dim">Automated regression detection on PR</text>
+
+  <!-- Arrow: compare → CI -->
+  <line x1="645" y1="250" x2="645" y2="270" class="arrow-purple" stroke-width="1" stroke-dasharray="4,3" marker-end="url(#ahp)"/>
+
+  <!-- Legend -->
+  <text x="32" y="390" font-size="9" class="text-dim">Solid = implemented</text>
+  <text x="32" y="404" font-size="9" class="text-purple">Dashed = proposed</text>
+  <text x="32" y="418" font-size="9" class="text-green">Green = evaluation targets</text>
 
   <!-- Footer -->
-  <text x="400" y="495" text-anchor="middle" font-size="11" class="text-dim">github.com/aclater/ragprobe · promptfoo + Python agent · AGPL-3.0</text>
+  <text x="400" y="648" text-anchor="middle" font-size="10" class="text-dim">github.com/aclater/ragprobe | promptfoo + Ragas + Python agent | AGPL-3.0</text>
 </svg>


### PR DESCRIPTION
## Summary
- Updated `architecture.svg` to reflect the current ragprobe architecture
- Shows dual-target comparison flow: ragpipe:8090 (plain RAG) vs ragorchestrator:8095 (agentic RAG)
- Added Ragas evaluation pipeline with 5 metrics (faithfulness, answer_relevance, context_precision, context_recall, ragas_score)
- Added Postgres probe_results storage and compare_targets.py regression detection
- Tuning agent loop and CI integration shown as proposed (dashed borders)
- Dark/light mode compatible via `prefers-color-scheme` media query
- All 13 test categories and custom assertions visible

## Test plan
- [ ] Verify SVG renders correctly on GitHub in both light and dark mode
- [ ] Confirm all architectural components from issue #32 are represented

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)